### PR TITLE
Serial number provider/zad3/plagodzinski v2

### DIFF
--- a/SerialNumberProvider/SerialNumberProvider.Api/Controllers/SerialNumberController.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Api/Controllers/SerialNumberController.cs
@@ -1,3 +1,4 @@
+
 using Microsoft.AspNetCore.Mvc;
 using SerialNumberProvider.Api.Models;
 using SerialNumberProvider.Core.Services.Abstract;
@@ -29,6 +30,20 @@ namespace SerialNumberProvider.Api.Controllers
             return Ok(generatedSerialNumber);
         }
 
+
+        [HttpPost("customGenerate")]
+        [ProducesResponseType(typeof(string), 200)]
+        public IActionResult GetSerialNumberForDevice(GenerateSerialNumberRequestModel requestModel, bool isMicrowave)
+        {
+            GenerateSerialNumberRequest request = PrepareGenerateSerialNumberRequest(requestModel);
+
+            string generatedSerialNumber = _serialNumberGenerator.GenerateSerialNumber(request, isMicrowave);
+
+            return Ok(generatedSerialNumber);
+        }
+
+
+
         [HttpPost("validate")]
         [ProducesResponseType(typeof(bool), 200)]
         public IActionResult ValidateSerialNumberForDevice(ValidateSerialNumberRequestModel requestModel)
@@ -43,7 +58,7 @@ namespace SerialNumberProvider.Api.Controllers
         private static GenerateSerialNumberRequest PrepareGenerateSerialNumberRequest(
             GenerateSerialNumberRequestModel response)
             => new GenerateSerialNumberRequest(response.Id, response.Name, response.Version, response.ProductionDate);
-        
+
         private static ValidateSerialNumberRequest PrepareValidateSerialNumberRequest(
             ValidateSerialNumberRequestModel response)
             => new ValidateSerialNumberRequest(response.Id, response.Name, response.Version, response.ProductionDate,

--- a/SerialNumberProvider/SerialNumberProvider.Api/Controllers/SerialNumberController.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Api/Controllers/SerialNumberController.cs
@@ -23,7 +23,7 @@ namespace SerialNumberProvider.Api.Controllers
         public IActionResult GetSHA256SerialNumberForDevice(GenerateSerialNumberRequestModel requestModel)
         {
             GenerateSerialNumberRequest request = PrepareGenerateSerialNumberRequest(requestModel);
-            
+
             string generatedSerialNumber = _serialNumberGenerator.GenerateSHA256SerialNumber(request);
 
             return Ok(generatedSerialNumber);
@@ -47,10 +47,12 @@ namespace SerialNumberProvider.Api.Controllers
         {
             ValidateSerialNumberRequest request = PrepareValidateSerialNumberRequest(requestModel);
 
-            bool isCorrect = _serialNumberValidator.ValidateSHA256(request);
-            if (isCorrect == false)
-                _serialNumberValidator.ValidateMD5(request);
-            return Ok(isCorrect);
+            if (_serialNumberValidator.ValidateSHA256(request) == true)
+                return Ok(true);
+            else if (_serialNumberValidator.ValidateMD5(request) == true)
+                return Ok(true);
+            else
+                return Ok(false);
         }
 
         private static GenerateSerialNumberRequest PrepareGenerateSerialNumberRequest(

--- a/SerialNumberProvider/SerialNumberProvider.Api/Controllers/SerialNumberController.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Api/Controllers/SerialNumberController.cs
@@ -1,4 +1,3 @@
-
 using Microsoft.AspNetCore.Mvc;
 using SerialNumberProvider.Api.Models;
 using SerialNumberProvider.Core.Services.Abstract;
@@ -19,25 +18,25 @@ namespace SerialNumberProvider.Api.Controllers
             _serialNumberValidator = serialNumberValidator;
         }
 
-        [HttpPost]
+        [HttpPost("sha256")]
         [ProducesResponseType(typeof(string), 200)]
-        public IActionResult GetSerialNumberForDevice(GenerateSerialNumberRequestModel requestModel)
+        public IActionResult GetSHA256SerialNumberForDevice(GenerateSerialNumberRequestModel requestModel)
         {
             GenerateSerialNumberRequest request = PrepareGenerateSerialNumberRequest(requestModel);
-
-            string generatedSerialNumber = _serialNumberGenerator.GenerateSerialNumber(request);
+            
+            string generatedSerialNumber = _serialNumberGenerator.GenerateSHA256SerialNumber(request);
 
             return Ok(generatedSerialNumber);
         }
 
 
-        [HttpPost("customGenerate")]
+        [HttpPost("MD5")]
         [ProducesResponseType(typeof(string), 200)]
-        public IActionResult GetSerialNumberForDevice(GenerateSerialNumberRequestModel requestModel, bool isMicrowave)
+        public IActionResult GetMD5SerialNumberForDevice(GenerateSerialNumberRequestModel requestModel)
         {
             GenerateSerialNumberRequest request = PrepareGenerateSerialNumberRequest(requestModel);
 
-            string generatedSerialNumber = _serialNumberGenerator.GenerateSerialNumber(request, isMicrowave);
+            string generatedSerialNumber = _serialNumberGenerator.GenerateMD5SerialNumber(request);
 
             return Ok(generatedSerialNumber);
         }
@@ -48,8 +47,9 @@ namespace SerialNumberProvider.Api.Controllers
         {
             ValidateSerialNumberRequest request = PrepareValidateSerialNumberRequest(requestModel);
 
-            bool isCorrect = _serialNumberValidator.Validate(request);
-
+            bool isCorrect = _serialNumberValidator.ValidateSHA256(request);
+            if (isCorrect == false)
+                _serialNumberValidator.ValidateMD5(request);
             return Ok(isCorrect);
         }
 

--- a/SerialNumberProvider/SerialNumberProvider.Api/Controllers/SerialNumberController.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Api/Controllers/SerialNumberController.cs
@@ -42,8 +42,6 @@ namespace SerialNumberProvider.Api.Controllers
             return Ok(generatedSerialNumber);
         }
 
-
-
         [HttpPost("validate")]
         [ProducesResponseType(typeof(bool), 200)]
         public IActionResult ValidateSerialNumberForDevice(ValidateSerialNumberRequestModel requestModel)

--- a/SerialNumberProvider/SerialNumberProvider.Core/Services/Abstract/ISerialNumberGenerator.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Core/Services/Abstract/ISerialNumberGenerator.cs
@@ -6,5 +6,7 @@ namespace SerialNumberProvider.Core.Services.Abstract
     public interface ISerialNumberGenerator
     {
         string GenerateSerialNumber(GenerateSerialNumberRequest request);
+        string GenerateSerialNumber(GenerateSerialNumberRequest request, bool isMicrowave);
+
     }
 }

--- a/SerialNumberProvider/SerialNumberProvider.Core/Services/Abstract/ISerialNumberGenerator.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Core/Services/Abstract/ISerialNumberGenerator.cs
@@ -5,7 +5,7 @@ namespace SerialNumberProvider.Core.Services.Abstract
 {
     public interface ISerialNumberGenerator
     {
-        string GenerateSerialNumber(GenerateSerialNumberRequest request);
-        string GenerateSerialNumber(GenerateSerialNumberRequest request, bool isMicrowave);
+        string GenerateSHA256SerialNumber(GenerateSerialNumberRequest request);
+        string GenerateMD5SerialNumber(GenerateSerialNumberRequest request);
     }
 }

--- a/SerialNumberProvider/SerialNumberProvider.Core/Services/Abstract/ISerialNumberGenerator.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Core/Services/Abstract/ISerialNumberGenerator.cs
@@ -7,6 +7,5 @@ namespace SerialNumberProvider.Core.Services.Abstract
     {
         string GenerateSerialNumber(GenerateSerialNumberRequest request);
         string GenerateSerialNumber(GenerateSerialNumberRequest request, bool isMicrowave);
-
     }
 }

--- a/SerialNumberProvider/SerialNumberProvider.Core/Services/Abstract/ISerialNumberValidator.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Core/Services/Abstract/ISerialNumberValidator.cs
@@ -4,6 +4,7 @@ namespace SerialNumberProvider.Core.Services.Abstract
 {
     public interface ISerialNumberValidator
     {
-        bool Validate(ValidateSerialNumberRequest validateSerialNumberRequest);
+        bool ValidateSHA256(ValidateSerialNumberRequest validateSerialNumberRequest);
+        bool ValidateMD5(ValidateSerialNumberRequest validateSerialNumberRequest);
     }
 }

--- a/SerialNumberProvider/SerialNumberProvider.Core/Services/Concrete/SerialNumberGenerator.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Core/Services/Concrete/SerialNumberGenerator.cs
@@ -7,30 +7,31 @@ namespace SerialNumberProvider.Core.Services.Concrete
 {
     public class SerialNumberGenerator : ISerialNumberGenerator
     {
-        public string GenerateSerialNumber(GenerateSerialNumberRequest request)
+
+        public string GenerateSHA256SerialNumber(GenerateSerialNumberRequest request)
             => ComputeSha256Hash($"{request.Id}+{request.Version}+{request.Name}+{request.ProductionDate.Ticks}");
-        public string GenerateSerialNumber(GenerateSerialNumberRequest request, bool isMicrowave)
-        => ComputeMD5Hash($"{request.Id}+{request.Version}+{request.Name}+{request.ProductionDate.Ticks}");
+        public string GenerateMD5SerialNumber(GenerateSerialNumberRequest request)
+            => ComputeMD5Hash($"{request.Id}+{request.Version}+{request.Name}+{request.ProductionDate.Ticks}");
+        
 
         private static string ComputeSha256Hash(string rawData)
         {
             using SHA256 sha256Hash = SHA256.Create();
             byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
 
-            StringBuilder builder = new StringBuilder();
-            foreach (byte t in bytes)
-            {
-                builder.Append(t.ToString("x2"));
-            }
-
-            return builder.ToString();
+            return BuildHash(bytes);
         }
 
         private static string ComputeMD5Hash(string rawData)
         {
-            using MD5 sha256Hash = MD5.Create();
-            byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
+            using MD5 md5Hash = MD5.Create();
+            byte[] bytes = md5Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
 
+            return BuildHash(bytes);
+        }
+
+        private static string BuildHash(byte[] bytes)
+        {
             StringBuilder builder = new StringBuilder();
             foreach (byte t in bytes)
             {

--- a/SerialNumberProvider/SerialNumberProvider.Core/Services/Concrete/SerialNumberGenerator.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Core/Services/Concrete/SerialNumberGenerator.cs
@@ -9,10 +9,26 @@ namespace SerialNumberProvider.Core.Services.Concrete
     {
         public string GenerateSerialNumber(GenerateSerialNumberRequest request)
             => ComputeSha256Hash($"{request.Id}+{request.Version}+{request.Name}+{request.ProductionDate.Ticks}");
+        public string GenerateSerialNumber(GenerateSerialNumberRequest request, bool isMicrowave)
+        => ComputeMD5Hash($"{request.Id}+{request.Version}+{request.Name}+{request.ProductionDate.Ticks}");
 
         private static string ComputeSha256Hash(string rawData)
         {
             using SHA256 sha256Hash = SHA256.Create();
+            byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
+
+            StringBuilder builder = new StringBuilder();
+            foreach (byte t in bytes)
+            {
+                builder.Append(t.ToString("x2"));
+            }
+
+            return builder.ToString();
+        }
+
+        private static string ComputeMD5Hash(string rawData)
+        {
+            using MD5 sha256Hash = MD5.Create();
             byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
 
             StringBuilder builder = new StringBuilder();

--- a/SerialNumberProvider/SerialNumberProvider.Core/Services/Concrete/SerialNumberGenerator.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Core/Services/Concrete/SerialNumberGenerator.cs
@@ -12,7 +12,6 @@ namespace SerialNumberProvider.Core.Services.Concrete
             => ComputeSha256Hash($"{request.Id}+{request.Version}+{request.Name}+{request.ProductionDate.Ticks}");
         public string GenerateMD5SerialNumber(GenerateSerialNumberRequest request)
             => ComputeMD5Hash($"{request.Id}+{request.Version}+{request.Name}+{request.ProductionDate.Ticks}");
-        
 
         private static string ComputeSha256Hash(string rawData)
         {

--- a/SerialNumberProvider/SerialNumberProvider.Core/Services/Concrete/SerialNumberValidator.cs
+++ b/SerialNumberProvider/SerialNumberProvider.Core/Services/Concrete/SerialNumberValidator.cs
@@ -12,10 +12,14 @@ namespace SerialNumberProvider.Core.Services.Concrete
             _serialNumberGenerator = serialNumberGenerator;
         }
 
-        public bool Validate(ValidateSerialNumberRequest validateSerialNumberRequest)
-            => NewGeneratedOne(validateSerialNumberRequest) == validateSerialNumberRequest.SerialNumberToValidate;
+        public bool ValidateSHA256(ValidateSerialNumberRequest validateSerialNumberRequest)
+            => NewGeneratedOneSHA256(validateSerialNumberRequest) == validateSerialNumberRequest.SerialNumberToValidate;
+        public bool ValidateMD5(ValidateSerialNumberRequest validateSerialNumberRequest)
+          => NewGeneratedOneMD5(validateSerialNumberRequest) == validateSerialNumberRequest.SerialNumberToValidate;
 
-        private string NewGeneratedOne(GenerateSerialNumberRequest generateSerialNumberRequest)
-            => _serialNumberGenerator.GenerateSerialNumber(generateSerialNumberRequest);
+        private string NewGeneratedOneSHA256(GenerateSerialNumberRequest generateSerialNumberRequest)
+            => _serialNumberGenerator.GenerateSHA256SerialNumber(generateSerialNumberRequest);
+        private string NewGeneratedOneMD5(GenerateSerialNumberRequest generateSerialNumberRequest)
+          => _serialNumberGenerator.GenerateMD5SerialNumber(generateSerialNumberRequest);
     }
 }


### PR DESCRIPTION
v2 jest oparty o develop bo się pośpieszyłem i opublikowałem brancha pierwszego z wprowadzonymi zmianami. Starałem się wszystko zrobić zgodnie z Twoimi komentarzami, jedynie Jeżeli chodzi o  " Dodatkowo sugerowałbym utworzenie wspólnej metody, której parametrem będzie GenerateSerialNumberRequest a wynikiem string," to nie mogę sobie tego wyobrazić. Gdybym zrobił jedną wspólną metodę to nie miałbym jak wskazać czy chcę MD5 czy SHA256, no chyba, że wrzuciłbym dodatkowe pole-flagę w modelu requesta.  